### PR TITLE
fix test deprecation warning and invalid test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 test/db
+vendor/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ services:
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.7
+branches:
+  only: [master]

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.7
+  - 2.2.3
 branches:
   only: [master]

--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ group :test do
   gem 'mocha',         :require => 'mocha/setup'
   gem 'timecop'
   gem 'sqlite3',       '1.3.6'
+  gem 'pry'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,11 @@ gem 'bump'
 
 group :test do
   gem 'rake'
-  gem 'resque',        '1.17.1'
+  gem 'resque',        '~>1.25'
   gem 'minitest',      '~>4.7.5'
   gem 'minitest-rg'
   gem 'mocha',         :require => 'mocha/setup'
   gem 'timecop'
-  gem 'sqlite3',       '1.3.6'
+  gem 'sqlite3'
   gem 'pry'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,6 @@ GEM
     bump (0.5.0)
     coderay (1.1.0)
     i18n (0.6.11)
-    json (1.5.5)
     metaclass (0.0.4)
     method_source (0.8.2)
     minitest (4.7.5)
@@ -31,30 +30,32 @@ GEM
       minitest (< 5.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
+    mono_logger (1.1.0)
     multi_json (1.10.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rack (1.5.2)
+    rack (1.6.4)
     rack-protection (1.5.3)
       rack
     rake (10.3.2)
-    redis (2.2.2)
-    redis-namespace (1.0.4)
-      redis (< 3.0.0)
-    resque (1.17.1)
-      json (>= 1.4.6, < 1.6)
-      redis-namespace (~> 1.0.2)
+    redis (3.2.1)
+    redis-namespace (1.5.2)
+      redis (~> 3.0, >= 3.0.4)
+    resque (1.25.2)
+      mono_logger (~> 1.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
-    sinatra (1.4.5)
+    sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
+      tilt (>= 1.3, < 3)
     slop (3.6.0)
-    sqlite3 (1.3.6)
-    tilt (1.4.1)
+    sqlite3 (1.3.10)
+    tilt (2.0.1)
     timecop (0.7.1)
     tzinfo (0.3.41)
     vegas (0.1.11)
@@ -71,9 +72,9 @@ DEPENDENCIES
   mocha
   pry
   rake
-  resque (= 1.17.1)
+  resque (~> 1.25)
   resque-durable!
-  sqlite3 (= 1.3.6)
+  sqlite3
   timecop
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,15 +21,21 @@ GEM
     arel (3.0.3)
     builder (3.0.4)
     bump (0.5.0)
+    coderay (1.1.0)
     i18n (0.6.11)
     json (1.5.5)
     metaclass (0.0.4)
+    method_source (0.8.2)
     minitest (4.7.5)
     minitest-rg (1.1.1)
       minitest (< 5.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.10.1)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.5.2)
     rack-protection (1.5.3)
       rack
@@ -46,6 +52,7 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
+    slop (3.6.0)
     sqlite3 (1.3.6)
     tilt (1.4.1)
     timecop (0.7.1)
@@ -62,8 +69,12 @@ DEPENDENCIES
   minitest (~> 4.7.5)
   minitest-rg
   mocha
+  pry
   rake
   resque (= 1.17.1)
   resque-durable!
   sqlite3 (= 1.3.6)
   timecop
+
+BUNDLED WITH
+   1.10.6

--- a/test/queue_audit_test.rb
+++ b/test/queue_audit_test.rb
@@ -43,12 +43,10 @@ module Resque::Durable
           end
 
           it 'records the failure' do
-            @bad_audit.expects(:fail!)
+            QueueAudit.logger.expects(:error)
             QueueAudit.recover
           end
-
         end
-
       end
 
       describe 'save!' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,16 +1,19 @@
 require 'bundler/setup'
 
 require 'resque/durable'
-require 'mocha/setup'
-require 'timecop'
 require 'minitest/autorun'
 require 'minitest/rg'
+require 'mocha/setup'
+require 'timecop'
 
 require 'active_record'
+require 'logger'
 database_config = YAML.load_file(File.join(File.dirname(__FILE__), 'database.yml'))
 ActiveRecord::Schema.verbose = false
 ActiveRecord::Base.establish_connection(database_config['test'])
 ActiveRecord::Base.default_timezone = :utc
+ActiveRecord::Base.logger = Logger.new('/dev/null')
+
 require './test/schema'
 
 I18n.enforce_available_locales = true


### PR DESCRIPTION
Running the tests gave this warning:

```
*** Mocha deprecation warning: Test::Unit or MiniTest must be loaded *before* `require 'mocha/setup'`.

*** Mocha deprecation warning: If you're integrating with a test library other than Test::Unit or MiniTest, you should use `require 'mocha/api'` instead of `require 'mocha/setup'`.
```

and sure enough, when fixing the order, it revealed that a message expectation was incorrect. I updated the test to match the implementation, instead of visa-versa. It doesn't look as if `recover` ever called `fail!`.

/cc @osheroff @jcheatham 