### PR TITLE
Add background heartbeat opt-in feature

### DIFF
--- a/lib/resque/durable.rb
+++ b/lib/resque/durable.rb
@@ -3,10 +3,19 @@ module Resque
     autoload :GUID,       'resque/durable/guid'
     autoload :Monitor,    'resque/durable/monitor'
     autoload :QueueAudit, 'resque/durable/queue_audit'
+    autoload :BackgroundHeartbeat, 'resque/durable/background_heartbeat'
 
     def self.extended(base)
+      # The duration since the last heartbeat that the monitor will wait before
+      # re-enqueing the job.
       base.cattr_accessor :job_timeout
       base.job_timeout = 10.minutes
+
+      # How frequently a background thread will optimistically heartbeat the
+      # QueueAudit. Value must be smaller than job_timeout. Currently opt-in.
+      #
+      # Recommended value: `15.seconds`
+      base.cattr_accessor :background_heartbeat_interval
 
       base.cattr_accessor :auditor
       base.auditor = QueueAudit
@@ -46,9 +55,17 @@ module Resque
 
     def around_perform_manage_audit(*args)
       if a = audit(args)
-        a.heartbeat!
         return if a.complete?
-        yield
+        if background_heartbeat_interval
+          raise "background_heartbeat_interval (#{background_heartbeat_interval.inspect}) be smaller than job_timeout (#{job_timeout.inspect})" if background_heartbeat_interval >= job_timeout
+          BackgroundHeartbeat.new(audit(args), background_heartbeat_interval).with_heartbeat do
+            yield
+          end
+        else
+          a.heartbeat!
+          yield
+        end
+
         a.complete!
       else
         yield

--- a/lib/resque/durable/background_heartbeat.rb
+++ b/lib/resque/durable/background_heartbeat.rb
@@ -1,0 +1,83 @@
+require 'thread'
+
+module Resque
+  module Durable
+
+    # Creates a background thread to regularly heartbeat the queue audit.
+    class BackgroundHeartbeat
+      DEFAULT_INTERVAL = 15
+
+      def initialize(queue_audit, interval = nil)
+        @queue_audit  = queue_audit
+        @last_timeout = nil
+        @interval     = interval || DEFAULT_INTERVAL
+        @mutex        = Mutex.new
+        @cv           = ConditionVariable.new
+        @stop         = false
+        @thread       = nil
+      end
+
+      class << self
+        # only a separate method for easy stubbing
+        def exit_now!
+          abort
+        end
+      end
+
+      def with_heartbeat
+        start!
+        yield
+      ensure
+        stop_and_wait!
+      end
+
+      def heartbeat!
+        @last_timeout ||= @queue_audit.timeout_at
+        @last_timeout = @queue_audit.optimistic_heartbeat!(@last_timeout)
+      rescue StandardError => e
+        @queue_audit.logger.error("Exception in BackgroundHeartbeat thread: #{e.class.name}: #{e.message}")
+        self.class.exit_now!
+      ensure
+        ActiveRecord::Base.clear_active_connections!
+      end
+
+      def start!
+        raise "Thread is already running!" if @thread
+        @stop = false
+
+        # Perform immediately to reduce heartbeat race condition opportunities
+        heartbeat!
+
+        @thread = Thread.new do
+          while !@stop
+            heartbeat!
+
+            @mutex.synchronize do
+              @cv.wait(@mutex, @interval)
+            end
+          end
+        end
+      end
+
+      def stop_and_wait!
+        return unless @thread
+        # Prevent deadlock if called by the `heartbeat` thread, which can't wait for itself to die.
+        return signal_stop! if @thread == Thread.current
+        while @thread.alive?
+          signal_stop!
+          sleep 0.01
+        end
+        @thread.join
+        @thread = nil
+      end
+
+      # Signal the `heartbeat` thread to stop looping immediately. Safe to be call from any thread.
+      def signal_stop!
+        @mutex.synchronize do
+          @stop = true
+          @cv.signal
+        end
+      end
+    end
+  end
+end

--- a/resque-durable.gemspec
+++ b/resque-durable.gemspec
@@ -5,11 +5,6 @@ Gem::Specification.new do |s|
   s.summary  = 'Resque queue backed by database audits, with automatic retry'
   s.homepage = 'https://github.com/zendesk/resque-durable'
   s.license  = 'MIT'
-  s.files    = [
-    'lib/resque/durable.rb',
-    'lib/resque/durable/guid.rb',
-    'lib/resque/durable/monitor.rb',
-    'lib/resque/durable/queue_audit.rb'
-  ]
+  s.files    = `git ls-files lib`.split($/)
   s.add_runtime_dependency 'activerecord'
 end

--- a/test/background_heartbeat_test.rb
+++ b/test/background_heartbeat_test.rb
@@ -1,0 +1,38 @@
+require_relative './test_helper'
+
+module Resque::Durable
+  describe BackgroundHeartbeat do
+    let(:subject) { BackgroundHeartbeat.new(queue_audit, 0.01) }
+    let(:queue_audit) { QueueAudit.initialize_by_klass_and_args(MailQueueJob, [ 'hello' ]) }
+
+    before do
+      queue_audit.save!
+    end
+
+    describe '#with_heartbeat' do
+      it 'heartbeats in the background for the requested interval' do
+        # Thread timing is not deterministic. Using a 2x margin of variation.
+        # Locally, this averaged 88 with a stddev of 1.4
+        queue_audit.expects(:optimistic_heartbeat!).at_least(50)
+        subject.with_heartbeat do
+          sleep 1
+        end
+      end
+
+      it 'aborts if another thread heartbeats' do
+        BackgroundHeartbeat.expects(:exit_now!).at_least_once
+        subject.with_heartbeat do
+          queue_audit.heartbeat!
+          sleep 0.1
+        end
+      end
+
+      it 'starts a thread and shuts it down before returning' do
+        subject.with_heartbeat do
+          Thread.list.length.must_equal 2
+        end
+        Thread.list.length.must_equal 1
+      end
+    end
+  end
+end

--- a/test/background_heartbeat_test.rb
+++ b/test/background_heartbeat_test.rb
@@ -13,7 +13,7 @@ module Resque::Durable
       it 'heartbeats in the background for the requested interval' do
         # Thread timing is not deterministic. Using a 2x margin of variation.
         # Locally, this averaged 88 with a stddev of 1.4
-        queue_audit.expects(:optimistic_heartbeat!).at_least(50)
+        queue_audit.expects(:optimistic_heartbeat!).times((50..150))
         subject.with_heartbeat do
           sleep 1
         end

--- a/test/durable_test.rb
+++ b/test/durable_test.rb
@@ -100,5 +100,22 @@ module Resque::Durable
 
       end
     end
+
+    describe 'background heartbeating' do
+      before do
+        QueueAudit.delete_all
+        Resque.inline = true
+      end
+
+      after do
+        Resque.inline = false
+      end
+
+      it 'heartbeats continously in the background' do
+        time_travel = Time.now + 10.years
+        BackgroundHeartbeatTestJob.enqueue(time_travel)
+        QueueAudit.first.timeout_at.must_be :>, time_travel
+      end
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,6 +62,18 @@ module Resque
 
       cattr_accessor :fail
     end
+
+    class BackgroundHeartbeatTestJob
+      extend Resque::Durable
+      self.background_heartbeat_interval = 0.1
+      @queue = :test_queue
+
+      def self.perform(travel_to, audit)
+        Timecop.travel(Time.parse travel_to) do
+          sleep 0.2
+        end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
resque-durable supports explicitly heartbeating the audit to prevent the job from being retried after exceeding the job's timeout. However, few of our jobs explicitly heartbeat, and instead rely on having a large timeout. This causes failure-prone jobs to have unnecessarily high latencies before their re-try.

This introduces an opt-in feature to create a background thread that heartbeats the queue audit. It uses an [optimistic locking](https://en.wikipedia.org/wiki/Optimistic_concurrency_control) scheme to detect if separate instances of the same job are running concurrently, and causes all but he last one to heartbeat to abort. A separate job could be enqueued by durable's monitor if the job's timeout is too small, or the execution is unexpectedly paused.

Because the heartbeating occurs in a separate thread, this can consume extra MySQL connections. ActiveRecord's [connection pool](http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/ConnectionPool.html) may need increasing.

/cc @osheroff @steved @jcheatham 