### PR TITLE
`MyJob.enqueue` returns its QueueAudit

### DIFF
--- a/lib/resque/durable.rb
+++ b/lib/resque/durable.rb
@@ -37,6 +37,7 @@ module Resque
       end
 
       Resque.enqueue(self, *args)
+      audit
     rescue Exception => e
       enqueue_failed(e, args)
     end

--- a/test/durable_test.rb
+++ b/test/durable_test.rb
@@ -8,13 +8,12 @@ module Resque::Durable
         QueueAudit.delete_all
         GUID.stubs(:generate).returns('abc/1/12345')
         Resque.expects(:enqueue).with(Resque::Durable::MailQueueJob, :foo, :bar, 'abc/1/12345')
-        MailQueueJob.enqueue(:foo, :bar)
+        @audit = MailQueueJob.enqueue(:foo, :bar)
       end
 
       describe 'enqueue' do
         it 'creates an audit' do
-          audit = QueueAudit.find_by_enqueued_id('abc/1/12345')
-
+          audit = QueueAudit.find_by_enqueued_id(@audit.enqueued_id)
           assert_equal 'abc/1/12345', audit.enqueued_id
         end
 


### PR DESCRIPTION
I've frequently need the QueueAudit record after enqueueing a job. I think it's more sane if `enqueue` returns that, instead of the result of `Resque.enqueue`. [`Resque.enqueue` normally returns](https://github.com/resque/resque/blob/8b26e32beb5f55d912f6be6ef6e3afa55fb2633c/lib/resque.rb#L288-L289) "true if the job was queued, nil if the job was rejected by a before_enqueue hook".

This would be a non-reverse compatible change, so I'm fine doing a major semver bump for it. I didn't see anything in our code base that depends on the return value, or that even defines a `before_enqueue` hook.

/cc @steved @osheroff @jcheatham 
