### PR TITLE
[CCORE-294] Fix class method name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See /examples
 
 ### Re-enqueuing gracefully
 
-To re-enqueue the job gracefully, and without waiting for the the audit failure timeout, call the `re_enqueue_immediately!` class method at any point while performing the job (usually at or close to the end).
+To re-enqueue the job gracefully, and without waiting for the the audit failure timeout, call the `requeue_immediately!` class method at any point while performing the job (usually at or close to the end).
 
 Resque/Durable will not mark the job as complete. Instead, it will mark the job as failed and reset the exponential backoff. The background durable monitor will then re-enqueue the job as described above.
 


### PR DESCRIPTION
This is a follow-up to #7. Fixing the method name in the README.