### PR TITLE
Remove payload size validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Resque/Durable will not mark the job as complete. Instead, it will mark the job 
 
 A common use case for this would be to gracefully stop a long-running job for a worker restart, and retry the job as soon as possible after the worker restart.
 
+### Validating payload limits
+
+It is recommended to add a validation based on the limits of the `payload` column in your implementation. For example:
+
+```
+validates_length_of :payload_before_type_cast, :in => 1..5000
+```
+
 # When things go wrong
 
 Audits stick around, and will be retried, until completed or expired by the monitoring script (expiration is configurable).

--- a/lib/resque/durable/queue_audit.rb
+++ b/lib/resque/durable/queue_audit.rb
@@ -19,8 +19,6 @@ module Resque
       # created_at
       DEFAULT_DURATION = 10.minutes
 
-      validates_length_of    :payload_before_type_cast, :in => 1..5000
-
       validates_inclusion_of :duration, :in => 1.minute.to_i..3.hours.to_i
 
       scope :older_than, ->(date) { where('created_at < ?', date).limit(10000) }

--- a/test/queue_audit_test.rb
+++ b/test/queue_audit_test.rb
@@ -15,14 +15,6 @@ module Resque::Durable
         @audit = QueueAudit.initialize_by_klass_and_args(MailQueueJob, [ 'hello' ])
       end
 
-      it 'validates the payload is not larger than 5,000 characters' do
-        @audit.payload = [ 'a', 'bcd' ]
-        assert @audit.valid?
-        @audit.payload = [ 'a', 'b' * 5000 ]
-        assert !@audit.valid?
-        assert @audit.errors[:payload_before_type_cast]
-      end
-
       describe 'recover' do
 
         describe 'failing to retry' do


### PR DESCRIPTION
Remove `payload` size validation. This is implementation-dependent and should be added by users.