### PR TITLE
Cast audits to the defined auditor class for the job class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 4.0.1
+
+- Bug fix: Cast job audit to the configured auditor class when enqueuing
+
 # 4.0.0
 
 - Clean up expired audits using `delete_all` in batches of 10000 (#15)

--- a/lib/resque/durable/queue_audit.rb
+++ b/lib/resque/durable/queue_audit.rb
@@ -77,7 +77,7 @@ module Resque
       end
 
       def enqueue
-        job_klass.enqueue(*(payload.push(self)))
+        job_klass.enqueue(*(payload.push(becomes(job_klass.auditor))))
       end
 
       def duration

--- a/resque-durable.gemspec
+++ b/resque-durable.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name     = "resque-durable"
-  s.version  = "4.0.0"
+  s.version  = "4.0.1"
   s.authors  = ["Eric Chapweske", "Ben Osheroff"]
   s.summary  = "Resque queue backed by database audits, with automatic retry"
   s.homepage = "https://github.com/zendesk/resque-durable"

--- a/test/queue_audit_test.rb
+++ b/test/queue_audit_test.rb
@@ -13,6 +13,7 @@ module Resque::Durable
         @queue.data = []
 
         @audit = QueueAudit.initialize_by_klass_and_args(MailQueueJob, [ 'hello' ])
+        @alt_audit = QueueAudit.initialize_by_klass_and_args(AlternativeAuditorTestJob, [ 'foo' ])
       end
 
       describe 'recover' do
@@ -105,6 +106,11 @@ module Resque::Durable
         it 'sends the payload to the queue' do
           Resque.expects(:enqueue).with(MailQueueJob, 'hello', @audit.enqueued_id)
           @audit.enqueue
+        end
+
+        it 'sends the correct payload (no extra audit arg) when using an alternative auditor' do
+          Resque.expects(:enqueue).with(AlternativeAuditorTestJob, 'foo', @alt_audit.enqueued_id)
+          @alt_audit.enqueue
         end
 
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -71,6 +71,13 @@ module Resque
         end
       end
     end
+
+    class AlternativeAuditor < QueueAudit; end
+
+    class AlternativeAuditorTestJob
+      extend Resque::Durable
+      self.auditor = AlternativeAuditor
+    end
   end
 end
 


### PR DESCRIPTION
The Durable module exposes an `auditor` attribute that provides for assigning a custom audit class to a job class in place of the standard `QueueAudit`.

When a job is reenqueued from the database, the `QueueAudit` class pushes an instance of itself onto the arguments list and calls `enqueue` on the job class. In `enqueue`, in turn, the Durable module looks for an instance of the job class's audit class as the last argument in the list. If it finds one, it is popped from the list and its `enqueued_id` is pushed onto the list. If not, a new audit is constructed and its `enqueued_id` is pushed onto the list.

Currently, because the audit restored from the database is unconditionally instantiated as a `QueueAudit`, Durable cannot recognize it as the audit it needs when the job class has a custom `auditor` defined (such as a subclass of `QueueAudit`). When this happens, the original audit is inappropriately passed along as an extra job argument. This change resolves this issue by casting the audit type to the job class's `auditor` type before pushing it onto the job arguments list, so that it is recognized and handled appropriately.