### PR TITLE
[CCORESF2-1501] Don't use Thread#signal in heartbeat implementation

### DIFF
--- a/test/background_heartbeat_test.rb
+++ b/test/background_heartbeat_test.rb
@@ -34,6 +34,20 @@ module Resque::Durable
         end
         assert_equal base_thread_count, Thread.list.length
       end
+
+      describe 'with a long interval' do
+        let(:subject) { BackgroundHeartbeat.new(queue_audit, 100) }
+
+        it 'aborts if requested to' do
+          t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          subject.with_heartbeat do
+            sleep 1
+          end
+          t2 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          # The important thing is that this takes 1 second, not 100 seconds, so use a big delta.
+          assert_in_delta (t2 - t1), 1, 10
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This was working fine if the heartbeat thread was blocked in sleep, but if the heartbeat thread was in the process of calling MySQL it would send a SIGVTALRM to it (because the unblocking function is invoked). This had various undesirable side effects inside the mysql2 gem native extension, including rapid-fire disconnect/reconnect cycles every 10ms.

Instead, use a condition variable that the heartbeat thread will be blocked on during the "sleep" phase of the heartbeat. Then, the condvar will be signaled when canceling the heartbeat thread. This means that the heartbeat thread is interruptable during sleep, but will finish any pending call to mysql2 before exiting.

https://zendesk.atlassian.net/browse/CCORESF2-1501