### PR TITLE
Test with newer Redis and Resque

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           - rails6.0
           - rails6.1
           - rails7.0
+          - resque_1_and_redis_4
         include:
           - ruby-version: "2.7"
             gemfile: rails5.2

--- a/gemfiles/resque_1_and_redis_4.gemfile
+++ b/gemfiles/resque_1_and_redis_4.gemfile
@@ -1,0 +1,4 @@
+eval_gemfile("common.rb")
+
+gem "resque", "~> 1.27"
+gem "redis", "~> 4"

--- a/resque-durable.gemspec
+++ b/resque-durable.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.7"
 
   s.add_runtime_dependency("activerecord", ">= 5.2")
-  s.add_runtime_dependency("resque", "~> 1.27")
+  s.add_runtime_dependency("resque", ">= 1.27")
   s.add_runtime_dependency("uuidtools", "~> 2.2")
-  s.add_runtime_dependency("redis", "< 5")
+  s.add_runtime_dependency("redis")
 end


### PR DESCRIPTION
Allow using with newer Resque and Redis versions.

Also adding a gemfile to test with Resque v1.x and Redis 4.x.