### PR TITLE
CI: Fix triggering events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: push
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
 
 jobs:
   tests:


### PR DESCRIPTION
This being a public repo, we may see pull requests from forked repos. The "push" event triggers actions on the source repo, while the "pull_request" events trigger on _our_ repo. So, we should change to use "pull_request" events.

Also adding "workflow_dispatch" to still allow us to run CI without opening a PR.