### PR TITLE
v4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Unreleased
 
+# 4.1.1
+- Relax `resque` and `redis` dependency requirements
+
 # 4.1.0
-- Add support for Ruby 3.1 and 3.2 
+- Add support for Ruby 3.1 and 3.2
 - Add support for Rails 7.0
 - Drop support for Rails 5.1
 

--- a/gemfiles/common.rb
+++ b/gemfiles/common.rb
@@ -5,7 +5,6 @@ gemspec path: '..'
 gem "bump"
 gem "rake"
 gem "minitest"
-gem "minitest-rg"
 gem "mocha"
 gem "timecop"
 gem "pry"

--- a/resque-durable.gemspec
+++ b/resque-durable.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name     = "resque-durable"
-  s.version  = "4.1.0"
+  s.version  = "4.1.1"
   s.authors  = ["Eric Chapweske", "Ben Osheroff"]
   s.summary  = "Resque queue backed by database audits, with automatic retry"
   s.homepage = "https://github.com/zendesk/resque-durable"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,6 @@ require 'bundler/setup'
 
 require 'resque/durable'
 require 'minitest/autorun'
-require 'minitest/rg'
 require 'mocha/minitest'
 require 'timecop'
 


### PR DESCRIPTION
Prepping release to include https://github.com/zendesk/resque-durable/commit/cb7dec49fa223a12f05aa8e79ac4f844f1c3ed5d

`minitest-rg` changes are unrelated, but needed for CI to run correctly.