### PR TITLE
switch to trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,11 +2,23 @@ name: Publish Gem
 
 on:
   push:
-    tags: v*
+    branches: main
+    paths: lib/resque/durable/version.rb
+  workflow_dispatch:
 
 jobs:
-  call-workflow:
-    uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
-    secrets:
-      RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
-      RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}
+  push:
+    runs-on: ubuntu-latest
+    environment: rubygems-publish
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - uses: rubygems/release-gem@v1
+        with:
+          await-release: true

--- a/lib/resque/durable/version.rb
+++ b/lib/resque/durable/version.rb
@@ -1,0 +1,5 @@
+module Resque
+  module Durable
+    VERSION = "4.1.1"
+  end
+end

--- a/resque-durable.gemspec
+++ b/resque-durable.gemspec
@@ -1,6 +1,8 @@
+require_relative "lib/resque/durable/version"
+
 Gem::Specification.new do |s|
   s.name     = "resque-durable"
-  s.version  = "4.1.1"
+  s.version  = Resque::Durable::VERSION
   s.authors  = ["Eric Chapweske", "Ben Osheroff"]
   s.summary  = "Resque queue backed by database audits, with automatic retry"
   s.homepage = "https://github.com/zendesk/resque-durable"


### PR DESCRIPTION
Switches to [trusted publishing](https://guides.rubygems.org/trusted-publishing/) and a new, [RubyGems-provided Github action](https://github.com/rubygems/release-gem).

This workflow will be triggered automatically when `version.rb` changes in the `main` branch (it is also possible to publish a pre-release version from a branch by running this workflow manually).