### PR TITLE
bump version to 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 4.2.0
+
 - Add support for Rails 7.1
 - Drop support for Rails 5.2 and 6.0
 - Drop support for Ruby below 3.1

--- a/lib/resque/durable/version.rb
+++ b/lib/resque/durable/version.rb
@@ -1,5 +1,5 @@
 module Resque
   module Durable
-    VERSION = "4.1.1"
+    VERSION = "4.2.0"
   end
 end


### PR DESCRIPTION
Releases these changes:
- Add support for Rails 7.1
- Drop support for Rails 5.2 and 6.0
- Drop support for Ruby below 3.1
- Convert QueueAudit model into a mixin