### PR TITLE
remove await-release from publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,5 +20,3 @@ jobs:
         with:
           bundler-cache: true
       - uses: rubygems/release-gem@v1
-        with:
-          await-release: true


### PR DESCRIPTION
It’s not very stable, and I don’t think we’ve ever run into a problem that this step protects from: `rake release` exits with 0 and tells us that it has successfully published a gem even though actually the new version hasn’t been published.