### PR TITLE
Disable bundler cache and install dependencies in publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,5 +18,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          bundler-cache: true
+          bundler-cache: false
+      - name: Install dependencies
+        run: bundle install
       - uses: rubygems/release-gem@v1


### PR DESCRIPTION
The publishing workflow is failing due to `gem exec` not being available found? 

Although I haven't tracked down the root cause, I've updated the publish workflow to align with how we publish our other public gems to RubyGems.